### PR TITLE
fix typos in codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ In most cases you won't need to deal with computational_sequence but rather with
 
 ```python
 >>> from mmdatasdk import mmdataset
->>> cmumosei_highlevel=mmdataset(mmdataset.cmu_mosei.highlevel)
->>> cmumosi_highlevel=mmdataset(mmdataset.cmu_mosi.highlevel)
+>>> cmumosei_highlevel=mmdataset(mmdatasdk.cmu_mosei.highlevel)
+>>> cmumosi_highlevel=mmdataset(mmdatasdk.cmu_mosi.highlevel)
 ```
 
 This script will download high-level CMU-MOSEI features according to highlevel receipe. Each recipe is a key-value dictionary with key as the name you would like to refer to the computational sequence as (different than root name) and value is the link to download the computational seqeuence from. You can find the standard datasets in the /dataset/standard_datasets/ folder. 


### PR DESCRIPTION
The typos between "mmdataset" and "mmdatasdk" still exist in the new version of readme.md .