### PR TITLE
fixed metadata template

### DIFF
--- a/mmsdk/mmdatasdk/configurations/metadataconfigs.py
+++ b/mmsdk/mmdatasdk/configurations/metadataconfigs.py
@@ -1,16 +1,13 @@
-featuresetMetadataTemplate=	[
-			"root name",#name of the featureset
-			"computational sequence description",#name of the featureset
-			"dimension names"
-			"computational sequence version",#the version of featureset
-			"alignment compatible",#name of the featureset
-			"dataset name",#featureset belongs to which dataset
-			"dataset version",#the version of dataset
-			"creator",#the author of the featureset
-			"contact",#the contact of the featureset
-			"featureset bib citation",#citation for the paper related to this featureset
-			"dataset bib citation"#citation for the dataset
-			]
-
-
-
+featuresetMetadataTemplate = [
+    "root name",  # name of the featureset
+    "computational sequence description",  # name of the featureset
+    "dimension names",
+    "computational sequence version",  # the version of featureset
+    "alignment compatible",  # name of the featureset
+    "dataset name",  # featureset belongs to which dataset
+    "dataset version",  # the version of dataset
+                        "creator",  # the author of the featureset
+                        "contact",  # the contact of the featureset
+                        "featureset bib citation",  # citation for the paper related to this featureset
+                        "dataset bib citation"  # citation for the dataset
+]


### PR DESCRIPTION
# Fixed featuresetMetadataTemplate infos

The metadata Template used to detect and fill missing metadata was corrupted (missing `,`) leading the "missing metadata filler" to believe a `"computational sequence descriptiondimension names"` was missing from the metadata while deploying and asking the user to input it, sotpping the whole script.